### PR TITLE
Add support for more formats

### DIFF
--- a/BombRushRadio/BombRushRadio.cs
+++ b/BombRushRadio/BombRushRadio.cs
@@ -122,14 +122,31 @@ namespace BombRushRadio
                 AudioType type = AudioType.UNKNOWN;
                 switch (f.Split('.').Last().ToLower())
                 {
+                    case "aif":
+                    case "aiff":
+                        type = AudioType.AIFF;
+                        break;
+                    case "it":
+                        type = AudioType.IT;
+                        break;
+                    case "mod":
+                        type = AudioType.MOD;
+                        break;
+                    case "mp2":
                     case "mp3":
                         type = AudioType.MPEG;
+                        break;
+                    case "ogg":
+                        type = AudioType.OGGVORBIS;
+                        break;
+                    case "s3m":
+                        type = AudioType.S3M;
                         break;
                     case "wav":
                         type = AudioType.WAV;
                         break;
-                    case "ogg":
-                        type = AudioType.OGGVORBIS;
+                    case "xm":
+                        type = AudioType.XM;
                         break;
                     default:
                         yield return null;

--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ For it to work, you must use this launch property in steam: `WINEDLLOVERRIDES="w
 
 ## How to use
 
-Launch the game once, then navigate to your games root directory, go into **"Bomb Rush Cyberfunk_Data/StreamingAssets/Mods/BombRushRadio/Songs/"** which the mod should have created, then drag .mp3's in that folder.
+Launch the game once, then navigate to your games root directory, go into **"Bomb Rush Cyberfunk_Data/StreamingAssets/Mods/BombRushRadio/Songs/"** which the mod should have created, then drag your songs into that folder. Make sure it's a supported format.
+
+### Supported Formats
+- MP3
+- WAV
+- OGG
 
 The format is pretty simple, "**Artist-SongTitle**"
 

--- a/README.md
+++ b/README.md
@@ -39,9 +39,15 @@ For it to work, you must use this launch property in steam: `WINEDLLOVERRIDES="w
 Launch the game once, then navigate to your games root directory, go into **"Bomb Rush Cyberfunk_Data/StreamingAssets/Mods/BombRushRadio/Songs/"** which the mod should have created, then drag your songs into that folder. Make sure it's a supported format.
 
 ### Supported Formats
+- AIF(F)
+- IT
+- MOD
+- MP2
 - MP3
-- WAV
 - OGG
+- S3M
+- WAV
+- XM
 
 The format is pretty simple, "**Artist-SongTitle**"
 


### PR DESCRIPTION
Unity has support for more formats than just MP3, OGG, and WAV. This PR adds them to the mod.

List of supported formats with PR:
- AIF(F)
- IT
- MOD
- MP2
- MP3
- OGG
- S3M
- WAV
- XM

Requires #2.