### PR TITLE
Add option to preload cache on boot, enable reloading with caching.

### DIFF
--- a/BombRushRadio/Patches/MusicPlayer-Patches.cs
+++ b/BombRushRadio/Patches/MusicPlayer-Patches.cs
@@ -61,7 +61,7 @@ public class MusicTrackQueue_Patches_EvaluateNextTrack
     {
         Debug.Log("[BRR] Next Track!");
 
-        if (BombRushRadio.CacheAudios.Value)
+        if (BombRushRadio.CacheAudios.Value && !BombRushRadio.PreloadCache.Value)
         {
             MusicTrack t = __instance.currentMusicTracks[nextTrackIndex];
 
@@ -103,7 +103,7 @@ public class MusicPlayer_Patches_PlayFrom
         __instance.musicTrackQueue.ClearMusicQueue();
         __instance.musicTrackQueue.AddAllCurrentTracksToQueue();
 
-        if (BombRushRadio.CacheAudios.Value)
+        if (BombRushRadio.CacheAudios.Value && !BombRushRadio.PreloadCache.Value)
         {
             MusicTrack t = __instance.musicTrackQueue.currentMusicTracks[index];
 

--- a/BombRushRadio/Patches/MusicPlayerBuffer-Patches.cs
+++ b/BombRushRadio/Patches/MusicPlayerBuffer-Patches.cs
@@ -31,7 +31,7 @@ public class MusicPlayerBuffer_Patches
 
         if (t != null)
         {
-            if (BombRushRadio.CacheAudios.Value)
+            if (BombRushRadio.CacheAudios.Value && !BombRushRadio.PreloadCache.Value)
             {
                 t.AudioClip.UnloadAudioData();
                 t.AudioClip = null;

--- a/README.md
+++ b/README.md
@@ -37,16 +37,24 @@ You can also use folders, like this:
 # Config
 
 ```
-## Settings file was created by plugin Bomb Rush Radio! v1.3.1.0
+## Settings file was created by plugin Bomb Rush Radio! v1.4
 ## Plugin GUID: kade.bombrushradio
 
 [Audio]
 
-## Caches audios to disc (Pros: Memory is lowered significantly, Any startup load time after the first start is lowered significantly, Cons: Stutters on play (depending on audio size), Caching on disc can be expensive on storage (depending on audio size/format))
+## Caches audio to disk.
+## Pros: Memory is lowered significantly, any boot time after the first start is lowered significantly.
+## Cons: Stutters on play (depending on audio size), caching on disk can be expensive on storage. (depending on audio size/format)
 # Setting type: Boolean
 # Default value: false
 Caching = false
 
+## Preloads cached audio from disk.
+## Causes slightly longer boot with memory usage increasing like without cache, but prevents stuttering when a song plays.
+## Requires Caching to be enabled.
+# Setting type: Boolean
+# Default value: false
+PreloadCache = false
 
 ```
 


### PR DESCRIPTION
This PR adds a new option where the plugin can preload cached audio data on game boot. This will result in the memory usage going up just like without caching, but will load a lot faster than without caching and will also eliminate stutters in-game.

Additionally, song reloading is now enabled with caching. I didn't notice any issues from testing outside from the plugin attempting to unload audio data that already was unloaded, which I've fixed in this PR too. (maybe I fixed something in my previous PRs?)

Also slightly rewords caching description, using new lines to make it easier to read.