### PR TITLE
Add config option for shuffling

### DIFF
--- a/BombRushRadio/BombRushRadio.cs
+++ b/BombRushRadio/BombRushRadio.cs
@@ -19,6 +19,7 @@ namespace BombRushRadio
 
     public class BombRushRadio : BaseUnityPlugin
     {
+        public static ConfigEntry<bool> ShuffleAudio = null!;
         public static ConfigEntry<bool> CacheAudios = null!;
         public static ConfigEntry<bool> PreloadCache = null!;
         public static MusicPlayer mInstance;
@@ -274,7 +275,9 @@ namespace BombRushRadio
             Logger.LogInfo("[BRR] Bomb Rush Radio has been loaded!");
             loading = false;
 
-            if (!CacheAudios.Value || (CacheAudios.Value && PreloadCache.Value))
+            if (ShuffleAudio.Value)
+                Helpers.Shuffle(audios);
+            else if (!CacheAudios.Value || (CacheAudios.Value && PreloadCache.Value))
                 audios.Sort((t, t2) => String.Compare(t.AudioClip.name, t2.AudioClip.name, StringComparison.Ordinal));
 
             SanitizeSongs();
@@ -287,6 +290,9 @@ namespace BombRushRadio
                 Directory.CreateDirectory(songFolder);
 
             // bind to config
+            ShuffleAudio = Config.Bind("Audio", "Shuffle", false,
+                "Shuffles the music that gets added by Bomb Rush Radio.\nAlso makes song reloading act like a makeshift shuffle button. (excluding game songs)");
+
             CacheAudios = Config.Bind("Audio", "Caching", false,
                 "Caches audio to disk.\nPros: Memory is lowered significantly, any boot time after the first start is lowered significantly.\nCons: Stutters on play (depending on audio size), caching on disk can be expensive on storage. (depending on audio size/format)");
 

--- a/BombRushRadio/Helpers.cs
+++ b/BombRushRadio/Helpers.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Reptile;
+using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using UnityEngine;
@@ -7,6 +9,19 @@ namespace BombRushRadio;
 
 public class Helpers
 {
+    public static void Shuffle(List<MusicTrack> list)
+    {
+        int num = list.Count;
+        while (num > 1)
+        {
+            num--;
+            int index = UnityEngine.Random.Range(0, num + 1);
+            MusicTrack value = list[index];
+            list[index] = list[num];
+            list[num] = value;
+        }
+    }
+
     public static byte[] ConvertFloatToByte(float[] f)
     {
         var byteArray = new byte[f.Length * 4];

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ You can also use folders, like this:
 
 [Audio]
 
+## Shuffles the music that gets added by Bomb Rush Radio.
+## Also makes song reloading act like a makeshift shuffle button. (excluding game songs)
+# Setting type: Boolean
+# Default value: false
+Shuffle = false
+
 ## Caches audio to disk.
 ## Pros: Memory is lowered significantly, any boot time after the first start is lowered significantly.
 ## Cons: Stutters on play (depending on audio size), caching on disk can be expensive on storage. (depending on audio size/format)


### PR DESCRIPTION
Adds an option that makes BRR shuffle its songs whenever songs are loaded. This also makes the reload songs hotkey act like a makeshift shuffle button for BRR songs.

Requires #24.