### PR TITLE
Ignore case when sorting by AudioClip name

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -204,10 +204,9 @@ public class BombRushRadio : BaseUnityPlugin
         Logger.LogInfo("[BRR] Bomb Rush Radio has been loaded!");
         Loading = false;
 
-        Audios.Sort((t, t2) => string.Compare(t.AudioClip.name, t2.AudioClip.name, StringComparison.Ordinal));
+        Audios.Sort((t, t2) => string.Compare(t.AudioClip.name, t2.AudioClip.name, StringComparison.OrdinalIgnoreCase));
 
         SanitizeSongs();
-
     }
 
     private void Awake()


### PR DESCRIPTION
Fixes an oversight from #24, now makes the music app more closely match how it appears in Explorer.

![2023-12-14_13-10-44_explorer](https://github.com/Kade-github/BombRushRadio/assets/15317421/c50ef8fc-8d03-4999-b2d1-207e37a908f3)

![2023-12-14_13-10-28_Bomb_Rush_Cyberfunk](https://github.com/Kade-github/BombRushRadio/assets/15317421/d9a4e161-d913-4478-9a37-8ecf23c80a33)

The only issue remaining would be files being in the middle of folders.
(ex: `"Earth, Wind & Fire" (folder), "Fallen Angel" (file), "inabakumori" (folder)`)