### PR TITLE
Remove all code related to caching, remove cache folder

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -1,36 +1,11 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using UnityEngine;
 
 namespace BombRushRadio;
 
 public class Helpers
 {
-    public static byte[] ConvertFloatToByte(float[] f)
-    {
-        var byteArray = new byte[f.Length * 4];
-        Buffer.BlockCopy(f, 0, byteArray, 0, byteArray.Length);
-        return byteArray;
-    }
-
-    public static float[] ConvertByteToFloat(byte[] b)
-    {
-        var floatArray = new float[b.Length / 4];
-        Buffer.BlockCopy(b, 0, floatArray, 0, b.Length);
-        return floatArray;
-    }
-
-    public static AudioClip LoadACFromCache(string cacheFile, string tagFile)
-    {
-        float[] samples = ConvertByteToFloat(File.ReadAllBytes(cacheFile));
-        string[] c = File.ReadAllText(tagFile).Split(',');
-
-        var a = AudioClip.Create("cachedAudioAsset", int.Parse(c[0]), int.Parse(c[1]), int.Parse(c[2]), false);
-        a.SetData(samples, 0);
-        return a;
-    }
-
     public static string[] GetMetadata(string filePath, bool oldMethod)
     {
         string songName;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -19,7 +19,6 @@ public class BombRushRadio : BaseUnityPlugin
 
     public static MusicPlayer MInstance;
     public static List<MusicTrack> Audios = new();
-    public static Dictionary<string, string> FilePaths = new();
     public int ShouldBeDone;
     public int Done;
 
@@ -67,9 +66,7 @@ public class BombRushRadio : BaseUnityPlugin
 
             foreach (MusicTrack tr in toRemove)
             {
-                FilePaths.Remove(Helpers.FormatMetadata([tr.Artist, tr.Title], "dash"));
                 Audios.Remove(tr);
-
                 tr.AudioClip.UnloadAudioData();
             }
         }
@@ -80,20 +77,6 @@ public class BombRushRadio : BaseUnityPlugin
         string[] metadata = Helpers.GetMetadata(filePath, false);
 
         string songName = Helpers.FormatMetadata(metadata, "dash");
-        string validName = string.Concat(songName.Split(Path.GetInvalidFileNameChars()));
-
-        if (validName.Contains(','))
-        {
-            validName = string.Concat(validName.Split(','));
-        }
-
-        string cacheFile = Path.Combine(_cachePath, validName + ".cache");
-        string tagFile = Path.Combine(_cachePath, validName + ".tag");
-
-        if (!FilePaths.ContainsKey(songName))
-        {
-            FilePaths.Add(songName, cacheFile + "," + tagFile);
-        }
 
         // Escape special characters so we don't get an HTML error when we send the request
         filePath = UnityWebRequest.EscapeURL(filePath);
@@ -232,6 +215,12 @@ public class BombRushRadio : BaseUnityPlugin
         if (!Directory.Exists(_songFolder))
         {
             Directory.CreateDirectory(_songFolder);
+        }
+
+        // purge cache files
+        if (Directory.Exists(_cachePath))
+        {
+            Directory.Delete(_cachePath, true);
         }
 
         // bind to config


### PR DESCRIPTION
Removes code that was originally used for caching but is now unused because of caching no longer being an option. Also adds code that will delete the cache folder from the BepInEx cache since it's no longer needed and now just wastes space.