### PR TITLE
Fix tracker files not appearing when streaming is enabled

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -60,7 +60,7 @@ public class Helpers
             songArtist = songArtist.Trim();
         }
 
-        return new[]{songArtist, songName.Trim()};
+        return new[] { songArtist, songName.Trim() };
     }
 
     public static string FormatMetadata(string[] metadata, string type)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -28,6 +28,7 @@ public class BombRushRadio : BaseUnityPlugin
     public static bool InMainMenu = false;
     public static bool Loading;
 
+    private readonly AudioType[] _trackerTypes = new[] { AudioType.IT, AudioType.MOD, AudioType.S3M, AudioType.XM };
     private readonly string _songFolder = Path.Combine(Application.streamingAssetsPath, "Mods", "BombRushRadio", "Songs");
     private readonly string _cachePath = Path.Combine(Paths.CachePath, "BombRushRadio");
 
@@ -55,7 +56,7 @@ public class BombRushRadio : BaseUnityPlugin
                     Logger.LogInfo("[BRR] Adding " + tr.Title);
                 }
 
-                if (Loaded.FirstOrDefault(l => l == Helpers.FormatMetadata(new []{tr.Artist, tr.Title}, "dash")) == null)
+                if (Loaded.FirstOrDefault(l => l == Helpers.FormatMetadata(new[] { tr.Artist, tr.Title }, "dash")) == null)
                 {
                     Logger.LogInfo("[BRR] Removing " + tr.Title);
                     toRemove.Add(tr);
@@ -101,10 +102,7 @@ public class BombRushRadio : BaseUnityPlugin
                 musicTrack.isRepeatable = false;
 
                 var downloadHandler = (DownloadHandlerAudioClip) www.downloadHandler;
-                if (StreamAudio.Value)
-                {
-                    downloadHandler.streamAudio = true;
-                }
+                downloadHandler.streamAudio = StreamAudio.Value && !_trackerTypes.Contains(type);
 
                 AudioClip myClip = downloadHandler.audioClip;
                 myClip.name = filePath;

--- a/README.md
+++ b/README.md
@@ -43,24 +43,20 @@ You can also use folders, like this:
 # Config
 
 ```
-## Settings file was created by plugin Bomb Rush Radio! v1.7
-## Plugin GUID: kade.bombrushradio
+## Settings file was created by plugin BombRushRadio v1.7
+## Plugin GUID: BombRushRadio
 
-[Audio]
+[Settings]
 
-## Caches audio to disk.
-## Pros: Memory is lowered significantly, any boot time after the first start is lowered significantly.
-## Cons: Stutters on play (depending on audio size), caching on disk can be expensive on storage. (depending on audio size/format)
+## Whether to stream audio from disk or load at runtime (Streaming is faster but more CPU intensive)
 # Setting type: Boolean
-# Default value: false
-Caching = false
+# Default value: true
+Stream Audio = true
 
-## Preloads cached audio from disk.
-## Causes slightly longer boot with memory usage increasing like without cache, but prevents stuttering when a song plays.
-## Requires Caching to be enabled.
-# Setting type: Boolean
-# Default value: false
-PreloadCache = false
+## Keybind used for reloading songs.
+# Setting type: KeyCode
+# Default value: F1
+Reload Key = F1
 
 ```
 


### PR DESCRIPTION
With 1.7, tracker files would give this error in BepInEx's log:
```
[Error  : Unity Log] Tracker files (XM/IT/MOD/S3M) cannot be streamed in realtime but must be fully downloaded before they can play.
```

This PR fixes it by forcing streamAudio to off if the audio type is a tracker file.

Also updates the config in the README to reflect how it is in 1.7.