### PR TITLE
Fix BombRushRadio tracks not continuing when entering new stage

### DIFF
--- a/Patches/MusicPlayer-Patches.cs
+++ b/Patches/MusicPlayer-Patches.cs
@@ -107,7 +107,7 @@ public class MusicPlayer_Patches_RefreshMusicQueueForStage
         }
     }
 
-    static void Prefix(MusicPlayer __instance, ChapterMusic chapterMusic, MusicTrack trackToPlay, Stage stage)
+    static bool Prefix(MusicPlayer __instance, ChapterMusic chapterMusic, MusicTrack trackToPlay, Stage stage)
     {
         CurrentChapter = chapterMusic;
         CurrentStage = stage;
@@ -115,6 +115,7 @@ public class MusicPlayer_Patches_RefreshMusicQueueForStage
         Refresh(__instance, chapterMusic, stage);
 
         __instance.musicTrackQueue.UpdateMusicQueueForStage(trackToPlay);
+        return false;
     }
 }
 

--- a/Patches/StageManager-Patches.cs
+++ b/Patches/StageManager-Patches.cs
@@ -1,0 +1,22 @@
+using HarmonyLib;
+using Reptile;
+using System;
+using UnityEngine;
+
+namespace BombRushRadio;
+
+[HarmonyPatch(typeof(StageManager), nameof(StageManager.GetCurrentNonChapterTrackToPlay))]
+public class StageManager_Patches_NonChapterTrack
+{
+    private static void Postfix(int playbackSamples, ref int playbackSamplesToPlay, StageManager __instance, ref MusicTrack __result) {
+        if (__result == null) {
+            foreach (MusicTrack track in BombRushRadio.Audios) {
+                if (track.GetInstanceID() == __instance.baseModule.lastPlayingSongOnStageExistInstanceID) {
+                    __result = track;
+                    playbackSamplesToPlay = __instance.baseModule.lastPlayingSongOnStageExistSamples;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
checks for BRR tracks when searching for last played track and force skips unpatched MusicPlayer.RefreshMusicQueueForStage() method so BRR tracks stay loaded