### PR TITLE
Enforce streaming & remove cache purging code

### DIFF
--- a/Helpers.cs
+++ b/Helpers.cs
@@ -60,7 +60,7 @@ public class Helpers
             songArtist = songArtist.Trim();
         }
 
-        return new[]{songArtist, songName.Trim()};
+        return new[] { songArtist, songName.Trim() };
     }
 
     public static string FormatMetadata(string[] metadata, string type)

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -29,7 +29,6 @@ public class BombRushRadio : BaseUnityPlugin
 
     private readonly AudioType[] _trackerTypes = new[] { AudioType.IT, AudioType.MOD, AudioType.S3M, AudioType.XM };
     private readonly string _songFolder = Path.Combine(Application.streamingAssetsPath, "Mods", "BombRushRadio", "Songs");
-    private readonly string _cachePath = Path.Combine(Paths.CachePath, "BombRushRadio");
 
     public void SanitizeSongs()
     {
@@ -119,13 +118,6 @@ public class BombRushRadio : BaseUnityPlugin
     public IEnumerator LoadFile(string f)
     {
         string extension = Path.GetExtension(f).ToLowerInvariant().Substring(1);
-
-        if (extension is "cache" or "tag")
-        {
-            File.Delete(f); // Remove old cache files
-            yield return null;
-        }
-
         string[] metadata = Helpers.GetMetadata(f, false);
 
         if (Audios.Find(m => m.Artist == metadata[0] && m.Title == metadata[1]))
@@ -212,12 +204,6 @@ public class BombRushRadio : BaseUnityPlugin
         if (!Directory.Exists(_songFolder))
         {
             Directory.CreateDirectory(_songFolder);
-        }
-
-        // purge cache files
-        if (Directory.Exists(_cachePath))
-        {
-            Directory.Delete(_cachePath, true);
         }
 
         // bind to config

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -28,6 +28,7 @@ public class BombRushRadio : BaseUnityPlugin
     public static bool InMainMenu = false;
     public static bool Loading;
 
+    private readonly AudioType[] _trackerTypes = new[] { AudioType.IT, AudioType.MOD, AudioType.S3M, AudioType.XM };
     private readonly string _songFolder = Path.Combine(Application.streamingAssetsPath, "Mods", "BombRushRadio", "Songs");
     private readonly string _cachePath = Path.Combine(Paths.CachePath, "BombRushRadio");
 
@@ -55,7 +56,7 @@ public class BombRushRadio : BaseUnityPlugin
                     Logger.LogInfo("[BRR] Adding " + tr.Title);
                 }
 
-                if (Loaded.FirstOrDefault(l => l == Helpers.FormatMetadata(new []{tr.Artist, tr.Title}, "dash")) == null)
+                if (Loaded.FirstOrDefault(l => l == Helpers.FormatMetadata(new[] { tr.Artist, tr.Title }, "dash")) == null)
                 {
                     Logger.LogInfo("[BRR] Removing " + tr.Title);
                     toRemove.Add(tr);
@@ -101,10 +102,7 @@ public class BombRushRadio : BaseUnityPlugin
                 musicTrack.isRepeatable = false;
 
                 var downloadHandler = (DownloadHandlerAudioClip) www.downloadHandler;
-                if (StreamAudio.Value)
-                {
-                    downloadHandler.streamAudio = true;
-                }
+                downloadHandler.streamAudio = StreamAudio.Value && !_trackerTypes.Contains(type);
 
                 AudioClip myClip = downloadHandler.audioClip;
                 myClip.name = filePath;

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -15,7 +15,6 @@ namespace BombRushRadio;
 [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
 public class BombRushRadio : BaseUnityPlugin
 {
-    public static ConfigEntry<bool> StreamAudio;
     public static ConfigEntry<KeyCode> ReloadKey;
 
     public static MusicPlayer MInstance;
@@ -102,7 +101,7 @@ public class BombRushRadio : BaseUnityPlugin
                 musicTrack.isRepeatable = false;
 
                 var downloadHandler = (DownloadHandlerAudioClip) www.downloadHandler;
-                downloadHandler.streamAudio = StreamAudio.Value && !_trackerTypes.Contains(type);
+                downloadHandler.streamAudio = !_trackerTypes.Contains(type);
 
                 AudioClip myClip = downloadHandler.audioClip;
                 myClip.name = filePath;
@@ -222,7 +221,6 @@ public class BombRushRadio : BaseUnityPlugin
         }
 
         // bind to config
-        StreamAudio = Config.Bind("Settings", "Stream Audio", true, "Whether to stream audio from disk or load at runtime (Streaming is faster but more CPU intensive)");
         ReloadKey = Config.Bind("Settings", "Reload Key", KeyCode.F1, "Keybind used for reloading songs.");
 
         // load em

--- a/README.md
+++ b/README.md
@@ -48,11 +48,6 @@ You can also use folders, like this:
 
 [Settings]
 
-## Whether to stream audio from disk or load at runtime (Streaming is faster but more CPU intensive)
-# Setting type: Boolean
-# Default value: true
-Stream Audio = true
-
 ## Keybind used for reloading songs.
 # Setting type: KeyCode
 # Default value: F1

--- a/README.md
+++ b/README.md
@@ -43,24 +43,20 @@ You can also use folders, like this:
 # Config
 
 ```
-## Settings file was created by plugin Bomb Rush Radio! v1.7
-## Plugin GUID: kade.bombrushradio
+## Settings file was created by plugin BombRushRadio v1.7
+## Plugin GUID: BombRushRadio
 
-[Audio]
+[Settings]
 
-## Caches audio to disk.
-## Pros: Memory is lowered significantly, any boot time after the first start is lowered significantly.
-## Cons: Stutters on play (depending on audio size), caching on disk can be expensive on storage. (depending on audio size/format)
+## Whether to stream audio from disk or load at runtime (Streaming is faster but more CPU intensive)
 # Setting type: Boolean
-# Default value: false
-Caching = false
+# Default value: true
+Stream Audio = true
 
-## Preloads cached audio from disk.
-## Causes slightly longer boot with memory usage increasing like without cache, but prevents stuttering when a song plays.
-## Requires Caching to be enabled.
-# Setting type: Boolean
-# Default value: false
-PreloadCache = false
+## Keybind used for reloading songs.
+# Setting type: KeyCode
+# Default value: F1
+Reload Key = F1
 
 ```
 


### PR DESCRIPTION
Based on #39 to prevent a conflict, so I would recommend merging that PR first.

---
Given that the Steam Deck (and my friend's really crappy laptop) can run the game with the stream audio option just fine, I think it's safe to remove this option; especially given that disabling it would come at the cost of long boot times and very high memory usage.

This PR also removes all the code related to purging cache files, since it's been ~~several months~~ over a year since the switch to streaming. It's likely that people who haven't touched the game since either of these code additions would end up cleaning and/or redoing their BRR anyways.