### PR TITLE
README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 # BombRushRadio
 A Bomb Rush Cyberfunk mod that lets you add custom music into the game!
 
-## How to use
+## How to Use
 
-Launch the game once, then navigate to your games root directory, go into **"Bomb Rush Cyberfunk_Data/StreamingAssets/Mods/BombRushRadio/Songs/"** which the mod should have created, then drag your songs into that folder. Make sure it's a supported audio format.
+Launch the game, go to your game's local files, navigate to **"Bomb Rush Cyberfunk_Data/StreamingAssets/Mods/BombRushRadio/Songs"** (which would've been created by the mod), then drag your songs into that folder. Make sure it's a supported audio format.
 
 ### Supported Audio Formats
 - AIF(F)
@@ -21,26 +21,19 @@ Launch the game once, then navigate to your games root directory, go into **"Bom
 - XM
 - FLAC
 
-### Naming Convention
+### Folder & Song Formatting
 
-Songs without metadata should be formatted like this `SongName-Artist`
+Songs can be stored in the folder itself, or can be put into subfolders for organization. The mod will search through all folders stored in the Songs folder.
 
-If they do have a title/artist metadata field, this gets skipped.
+BombRushRadio will automatically detect the metadata from the song file. If metadata is not present, the file name will be displayed instead. You can still display the artist separately in the radio app by naming the file with the following format: `Song Name-Artist Name`.
 
-### Structure example
+## Reloading
 
-It should look like this:
+Want to reload songs on the fly? Make some changes (additions, removals, and modifications) in the song folder and press **F1** in-game.
 
-![image](https://github.com/Kade-github/BombRushRadio/assets/26305836/c30022e8-703f-4918-9a46-b70a65019be6)
+The keybind can be configured in the mod's config.
 
-
-You can also use folders, like this:
-
-![image](https://github.com/Kade-github/BombRushRadio/assets/26305836/dc977b6b-2e49-461f-94a2-e1a2955041b8)
-
-![image](https://github.com/Kade-github/BombRushRadio/assets/26305836/108a13ba-ce65-4b65-81cb-fb03a7b003ef)
-
-# Config
+## Config
 
 ```
 ## Settings file was created by plugin Bomb Rush Radio! v1.7
@@ -66,47 +59,13 @@ PreloadCache = false
 
 ## Installation
 
-### [THUNDERSTORE (CAN BE USED ON R2MODMAN)](https://thunderstore.io/c/bomb-rush-cyberfunk/p/Kade/BombRushRadio/)
-
-Go to the [latest release](https://github.com/Kade-github/BombRushRadio/releases/latest), and download either:
-
-### BepInEx Included
-
-A version of the mod with BepInEx included.
-
-To install:
-
-**Drag'N'Drop the contents of the zip inside of your games root directory**
-
-### Standalone
-
-You must have BepInEx already installed (make sure its 5.4!!)
-
-To install:
-
-**Put the .dll in your BepInEx/Plugins/ folder**
-
-It should look like this at the very end
-
-![image](https://github.com/Kade-github/BombRushRadio/assets/26305836/46ca5d9f-d041-44ee-9ffb-a969f357fa00)
-
-# STEAM DECK USERS
-
-For it to work, you must use this launch property in steam: `WINEDLLOVERRIDES="winhttp=n,b" %command%`
-
-
-
-## Reloading
-
-Want to reload songs on the fly? Make some changes in the song folder and press **F1** in game, it'll load any deletions/additions you make! (Not changes to files though)
+You can install BombRushRadio via [r2modman](https://thunderstore.io/c/bomb-rush-cyberfunk/p/ebkr/r2modman/), [GaleModManager](https://thunderstore.io/c/bomb-rush-cyberfunk/p/Kesomannen/GaleModManager/), or any other mod manager that integrates Thunderstore.
 
 ## Building
 
-Please follow this step in the Slopcrew Building file (as we use the exact same method to find the Assembly-CSharp.dll) [here](https://github.com/SlopCrew/SlopCrew/blob/main/docs/Developer%20Guide.md#building-slop-crew)
+Please follow this step in the SlopCrew building file (as we use the exact same method to find the Assembly-CSharp.dll) [here](https://github.com/SlopCrew/SlopCrew/blob/main/docs/Developer%20Guide.md#building-slop-crew), and then open the .csproj.
 
-And then open the .csproj.
-
-Make sure to add "https://nuget.bepinex.dev/v3/index.json" as a NuGet source. (in rider heres how it looks)
+Make sure to add "https://nuget.bepinex.dev/v3/index.json" as a NuGet source. (in rider here's how it looks)
 
 ![image](https://github.com/Kade-github/BombRushRadio/assets/26305836/e128d6c4-debd-4d02-a51b-85b7f8b21517)
 


### PR DESCRIPTION
- Rewording several segments
- Reworks naming and structure examples
- Reduce installation to just mentioning the Thunderstore mod loaders
- Slight cleanup with building segment

Closes #45, could potentially conflict with #39/#43's README change.